### PR TITLE
feat: Fix base image & Deploy `rocq/rocq-native:dev-native` as well

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,11 +6,11 @@
 [![pulls](https://img.shields.io/docker/pulls/rocq/rocq-prover.svg)](https://hub.docker.com/r/rocq/rocq-prover "Number of pulls from Docker Hub")
 [![stars](https://img.shields.io/docker/stars/rocq/rocq-prover.svg)](https://hub.docker.com/r/rocq/rocq-prover "Star the image on Docker Hub")  
 [![dockerfile](https://img.shields.io/badge/dockerfile%20on-gitlab-blue.svg)](https://gitlab.com/coq-community/docker-rocq "Dockerfile source repository")
-[![base](https://img.shields.io/badge/depends%20on-coqorg%2Fbase-blue.svg)](https://hub.docker.com/r/coqorg/base "Docker base image for Rocq")
+[![base](https://img.shields.io/badge/depends%20on-rocq%2Fbase-blue.svg)](https://hub.docker.com/r/rocq/base "Docker base image for Rocq")
 
 This repository provides [Docker](https://www.docker.com/) images of the [Rocq Prover](https://rocq-prover.org/).
 
-These images are based on [this parent image](https://hub.docker.com/r/coqorg/base/), itself based on [Debian 12 Slim](https://hub.docker.com/_/debian/) and relying on [opam 2.0](https://opam.ocaml.org/doc/Manual.html).
+These images are based on [this parent image](https://hub.docker.com/r/rocq/base/), itself based on [Debian 12 Slim](https://hub.docker.com/_/debian/) and relying on [opam 2.0](https://opam.ocaml.org/doc/Manual.html).
 
 <!-- TODO gh-action..debian tabular -->
 

--- a/images.yml
+++ b/images.yml
@@ -2,9 +2,9 @@
 base_url: 'https://gitlab.com/coq-community/docker-rocq'
 active: true
 docker_repo: 'rocq/rocq-prover'
-# vars:
+vars:
   # TODO: Update when appropriate
-  # coq_latest: '8.20.0'
+  rocq_latest: '8.20.1'
 args:
   BUILD_DATE: '{defaults[build_date]}'
 # propagate:
@@ -44,7 +44,7 @@ images:
   ## rocq/rocq-prover:dev-ocaml-*
   - matrix:
       default: ['4.14.2-flambda']
-      base: ['4.14.2-flambda']
+      base: ['4.14.2-flambda', '4.13.1-flambda', '4.12.1-flambda', '4.09.1-flambda']
       rocq: ['dev']
     build: &build_rocq_dev
       keywords:
@@ -56,7 +56,7 @@ images:
         repo: 'coq/coq'
         branch: 'master'
       args:
-        BASE_TAG: '{matrix[base]}'
+        BASE_TAG: 'rocq_{matrix[base]}'
         ROCQ_VERSION: '{matrix[rocq]}'
         ROCQ_COMMIT: '{defaults[commit]}'
         VCS_REF: '{defaults[commit][0:7]}'
@@ -71,3 +71,36 @@ images:
         # default tag (dev)
         - tag: '{matrix[rocq]}'
           if: '{matrix[base]} == {matrix[default]}'
+  ## rocq/rocq-prover:dev-native
+  - matrix:
+      # TODO: Bump default version
+      default: ['4.14.2']
+      base: ['4.14.2', '4.14.2-flambda']
+      rocq: ['dev']
+    build:
+      <<: *build_rocq_dev
+      # no need for gitlab pipeline trigger after coqorg/coq:dev-native's build
+      # after_deploy: []
+      args:
+        BASE_TAG: 'rocq_{matrix[base]}'
+        ROCQ_VERSION: '{matrix[rocq]}'
+        ROCQ_COMMIT: '{defaults[commit]}'
+        VCS_REF: '{defaults[commit][0:7]}'
+        ROCQ_EXTRA_OPAM: 'rocq-native coq-bignums'
+        ROCQ_INSTALL_SERAPI: ''
+        # as coq-serapi is not kept compatible with rocq.dev for now
+      tags:
+        # full tag
+        - tag: '{matrix[rocq]}-native-ocaml-{matrix[base]}'
+        # abbreviated tag (*-ocaml-4.14)
+        - tag: '{matrix[rocq]}-native-ocaml-{matrix[base][%.*]}'
+          if: '{matrix[base]} == {matrix[default]}'
+        # abbreviated tag (*-ocaml-4.14-flambda)
+        - tag: '{matrix[rocq]}-native-ocaml-{matrix[base][%.*-*]}-flambda'
+          if: '{matrix[base]} != {matrix[default]}'
+        # default tag (dev-native)
+        - tag: '{matrix[rocq]}-native'
+          if: '{matrix[base]} == {matrix[default]}'
+        # default tag (dev-native-flambda)
+        - tag: '{matrix[rocq]}-native-flambda'
+          if: '{matrix[base]} != {matrix[default]}'

--- a/rocq/dev/Dockerfile
+++ b/rocq/dev/Dockerfile
@@ -1,5 +1,5 @@
 ARG BASE_TAG="latest"
-FROM coqorg/base:${BASE_TAG}
+FROM rocq/base:${BASE_TAG}
 
 ARG ROCQ_EXTRA_OPAM="coq-bignums"
 ENV ROCQ_EXTRA_OPAM="${ROCQ_EXTRA_OPAM}"
@@ -9,7 +9,7 @@ ENV ROCQ_VERSION=${ROCQ_VERSION}
 
 ARG ROCQ_COMMIT
 
-# This line is actually unneeded (was already enabled in coqorg/base)
+# This line is actually unneeded (was already enabled in rocq/base)
 SHELL ["/bin/bash", "--login", "-o", "pipefail", "-c"]
 
 # hadolint ignore=SC2046
@@ -26,8 +26,7 @@ RUN set -x \
   && opam pin add -n -y -k git coq.${ROCQ_VERSION} "git+https://github.com/coq/coq#${ROCQ_COMMIT}" \
   && opam install -y -v -j "${NJOBS}" rocq-runtime rocq-core rocq-prover coqide-server coq-core coq ${ROCQ_EXTRA_OPAM} \
   && opam clean -a -c -s --logs \
-  # TODO-LATER: Use /home/rocq
-  && chmod -R g=u /home/coq/.opam \
+  && chmod -R g=u /home/rocq/.opam \
   && opam config list && opam list
 
 ARG BUILD_DATE


### PR DESCRIPTION
Follows-up: https://github.com/coq-community/docker-base/pull/33

5th step in the release of `rocq/rocq-prover:9.0-rc1`