### PR TITLE
Release `rocq/rocq-prover:9.0` (rc1)

### DIFF
--- a/images.yml
+++ b/images.yml
@@ -16,7 +16,7 @@ args:
 #       - when: 'rebuild-all'
 #         mode: 'rebuild-all'
 #       - when: 'forall'
-#         expr: '{matrix[coq][//pl/.][%.*]}'
+#         expr: '{matrix[rocq][//pl/.][%.*]}'
 #         subset: '8.4,8.5'
 #         mode: 'nil'
 #       - # when OPTIONAL for last rule
@@ -30,11 +30,11 @@ args:
 #       - when: 'rebuild-all'
 #         mode: 'minimal'
 #       - when: 'forall'
-#         expr: '{matrix[coq]}'
+#         expr: '{matrix[rocq]}'
 #         subset: 'dev'
 #         mode: 'nightly'
 #       - when: 'exists'
-#         expr: '{matrix[coq][//pl/.][%.*]}'
+#         expr: '{matrix[rocq][//pl/.][%.*]}'
 #         subset: '8.18,8.19,8.20,dev'
 #         mode: 'minimal'
 #       - # when OPTIONAL for last rule
@@ -61,12 +61,10 @@ images:
         ROCQ_COMMIT: '{defaults[commit]}'
         VCS_REF: '{defaults[commit][0:7]}'
         ROCQ_EXTRA_OPAM: 'coq-bignums'
-        ROCQ_INSTALL_SERAPI: ''
-        # as coq-serapi is not kept compatible with coq.dev for now
       tags:
         # full tag
         - tag: '{matrix[rocq]}-ocaml-{matrix[base]}'
-        # abbreviated tag (*-ocaml-4.13-flambda)
+        # abbreviated tag (*-ocaml-4.14-flambda)
         - tag: '{matrix[rocq]}-ocaml-{matrix[base][%.*-*]}-flambda'
         # default tag (dev)
         - tag: '{matrix[rocq]}'
@@ -79,7 +77,7 @@ images:
       rocq: ['dev']
     build:
       <<: *build_rocq_dev
-      # no need for gitlab pipeline trigger after coqorg/coq:dev-native's build
+      # no need for gitlab pipeline trigger after rocq/rocq-prover:dev-native's build
       # after_deploy: []
       args:
         BASE_TAG: 'rocq_{matrix[base]}'
@@ -87,8 +85,6 @@ images:
         ROCQ_COMMIT: '{defaults[commit]}'
         VCS_REF: '{defaults[commit][0:7]}'
         ROCQ_EXTRA_OPAM: 'rocq-native coq-bignums'
-        ROCQ_INSTALL_SERAPI: ''
-        # as coq-serapi is not kept compatible with rocq.dev for now
       tags:
         # full tag
         - tag: '{matrix[rocq]}-native-ocaml-{matrix[base]}'
@@ -104,3 +100,66 @@ images:
         # default tag (dev-native-flambda)
         - tag: '{matrix[rocq]}-native-flambda'
           if: '{matrix[base]} != {matrix[default]}'
+  ################################################################
+  ## rocq/rocq-prover:9.0-rc1
+  - matrix:
+      default: ['4.14.2-flambda']
+      # only *-flambda switches
+      base: ['4.14.2-flambda', '4.13.1-flambda', '4.12.1-flambda', '4.09.1-flambda']
+      rocq: ['9.0-rc1']
+    build: &build_rocq_alpha
+      context: './rocq'
+      dockerfile: './beta/Dockerfile'
+      keywords:
+        - '{matrix[rocq][%-*]}'
+      args:
+        BASE_TAG: 'rocq_{matrix[base]}'
+        ROCQ_VERSION: '{matrix[rocq][//-/+]}'
+        VCS_REF: 'V{matrix[rocq][//-/+]}'
+        ROCQ_EXTRA_OPAM: 'coq-bignums'
+        # +- rocq-native
+      tags:
+        # full tag
+        - tag: '{matrix[rocq]}-ocaml-{matrix[base]}'
+        # abbreviated tag (*-ocaml-4.14-flambda)
+        - tag: '{matrix[rocq][%-*]}-ocaml-{matrix[base][%.*-*]}-flambda'
+        # default tag (9.0-alpha)
+        - tag: '{matrix[rocq]}'
+          if: '{matrix[base]} == {matrix[default]}'
+        # abbreviated tag (9.0)
+        - tag: '{matrix[rocq][%-*]}'
+          if: '{matrix[base]} == {matrix[default]}'
+   # rocq/rocq-prover:9.0-rc1-native
+  - matrix:
+      default: ['4.14.2']
+      base: ['4.14.2', '4.14.2-flambda']
+      rocq: ['9.20-rc1']
+    build:
+      <<: *build_rocq_alpha
+      args:
+        BASE_TAG: 'rocq_{matrix[base]}'
+        ROCQ_VERSION: '{matrix[rocq][//-/+]}'
+        VCS_REF: 'V{matrix[rocq][//-/+]}'
+        ROCQ_EXTRA_OPAM: 'rocq-native coq-bignums'
+        # +- rocq-native
+      tags:
+        # full tag
+        - tag: '{matrix[rocq]}-native-ocaml-{matrix[base]}'
+        # abbreviated tag (*-ocaml-4.14)
+        - tag: '{matrix[rocq][%-*]}-native-ocaml-{matrix[base][%.*]}'
+          if: '{matrix[base]} == {matrix[default]}'
+        # abbreviated tag (*-ocaml-4.14-flambda)
+        - tag: '{matrix[rocq][%-*]}-native-ocaml-{matrix[base][%.*-*]}-flambda'
+          if: '{matrix[base]} != {matrix[default]}' # -flambda
+        # default tag (9.0-alpha-native)
+        - tag: '{matrix[rocq]}-native'
+          if: '{matrix[base]} == {matrix[default]}'
+        # default tag (9.0-alpha-native-flambda)
+        - tag: '{matrix[rocq]}-native-flambda'
+          if: '{matrix[base]} != {matrix[default]}' # -flambda
+        # abbreviated tag (9.0-native)
+        - tag: '{matrix[rocq][%-*]}-native'
+          if: '{matrix[base]} == {matrix[default]}'
+        # abbreviated tag (9.0-native-flambda)
+        - tag: '{matrix[rocq][%-*]}-native-flambda'
+          if: '{matrix[base]} != {matrix[default]}' # -flambda

--- a/rocq/beta/Dockerfile
+++ b/rocq/beta/Dockerfile
@@ -1,0 +1,36 @@
+ARG BASE_TAG="latest"
+FROM rocq/base:${BASE_TAG}
+
+ARG ROCQ_EXTRA_OPAM="coq-bignums"
+ENV ROCQ_EXTRA_OPAM="${ROCQ_EXTRA_OPAM}"
+
+ARG ROCQ_VERSION="dev"
+ENV ROCQ_VERSION=${ROCQ_VERSION}
+
+# This line is actually unneeded (was already enabled in rocq/base)
+SHELL ["/bin/bash", "--login", "-o", "pipefail", "-c"]
+
+# hadolint ignore=SC2046
+RUN set -x \
+  && eval $(opam env "--switch=${COMPILER}" --set-switch) \
+  && opam repository add --all-switches --set-default rocq-extra-dev https://coq.inria.fr/opam/extra-dev \
+  && opam repository add --all-switches --set-default rocq-core-dev https://coq.inria.fr/opam/core-dev \
+  && opam update -y -u \
+  && opam pin add -n -k version rocq-prover ${ROCQ_VERSION} \
+  && opam install -y -v -j "${NJOBS}" rocq-prover ${ROCQ_EXTRA_OPAM} \
+  && opam clean -a -c -s --logs \
+  && chmod -R g=u /home/rocq/.opam \
+  && opam config list && opam list
+
+ARG BUILD_DATE
+ARG VCS_REF
+LABEL org.label-schema.build-date=${BUILD_DATE} \
+  org.label-schema.name="The Rocq Prover" \
+  org.label-schema.description="Rocq is a formal proof management system. It provides a formal language to write mathematical definitions, executable algorithms and theorems together with an environment for semi-interactive development of machine-checked proofs." \
+  org.label-schema.url="https://rocq-prover.org/" \
+  org.label-schema.vcs-ref=${VCS_REF} \
+  org.label-schema.vcs-url="https://github.com/coq/coq" \
+  org.label-schema.vendor="The Rocq Development Team" \
+  org.label-schema.version=${ROCQ_VERSION} \
+  org.label-schema.schema-version="1.0" \
+  maintainer="erik@martin-dorel.org"

--- a/rocq/dev/Dockerfile
+++ b/rocq/dev/Dockerfile
@@ -15,8 +15,8 @@ SHELL ["/bin/bash", "--login", "-o", "pipefail", "-c"]
 # hadolint ignore=SC2046
 RUN set -x \
   && eval $(opam env "--switch=${COMPILER}" --set-switch) \
-  && opam repository add --all-switches --set-default coq-extra-dev https://coq.inria.fr/opam/extra-dev \
-  && opam repository add --all-switches --set-default coq-core-dev https://coq.inria.fr/opam/core-dev \
+  && opam repository add --all-switches --set-default rocq-extra-dev https://coq.inria.fr/opam/extra-dev \
+  && opam repository add --all-switches --set-default rocq-core-dev https://coq.inria.fr/opam/core-dev \
   && opam update -y -u \
   && opam pin add -n -y -k git rocq-runtime.${ROCQ_VERSION} "git+https://github.com/coq/coq#${ROCQ_COMMIT}" \
   && opam pin add -n -y -k git rocq-core.${ROCQ_VERSION} "git+https://github.com/coq/coq#${ROCQ_COMMIT}" \


### PR DESCRIPTION
Cc @mattam82 @proux01 FYI

Follows-up: https://github.com/coq-community/docker-rocq/pull/3

6th step in the release of `rocq/rocq-prover:9.0-rc1`

Let's wait for the CI

After the merge:
* Remove `coqorg/coq:dev` from the Docker-Coq repo;
* Update mathcomp images