### PR TITLE
fix: s/coq-bignums/rocq-bignums

### DIFF
--- a/images.yml
+++ b/images.yml
@@ -60,7 +60,7 @@ images:
         ROCQ_VERSION: '{matrix[rocq]}'
         ROCQ_COMMIT: '{defaults[commit]}'
         VCS_REF: '{defaults[commit][0:7]}'
-        ROCQ_EXTRA_OPAM: 'coq-bignums'
+        ROCQ_EXTRA_OPAM: 'rocq-bignums'
       tags:
         # full tag
         - tag: '{matrix[rocq]}-ocaml-{matrix[base]}'
@@ -84,7 +84,7 @@ images:
         ROCQ_VERSION: '{matrix[rocq]}'
         ROCQ_COMMIT: '{defaults[commit]}'
         VCS_REF: '{defaults[commit][0:7]}'
-        ROCQ_EXTRA_OPAM: 'rocq-native coq-bignums'
+        ROCQ_EXTRA_OPAM: 'rocq-native rocq-bignums'
       tags:
         # full tag
         - tag: '{matrix[rocq]}-native-ocaml-{matrix[base]}'
@@ -116,7 +116,7 @@ images:
         BASE_TAG: 'rocq_{matrix[base]}'
         ROCQ_VERSION: '{matrix[rocq][//-/+]}'
         VCS_REF: 'V{matrix[rocq][//-/+]}'
-        ROCQ_EXTRA_OPAM: 'coq-bignums'
+        ROCQ_EXTRA_OPAM: 'rocq-bignums'
         # +- rocq-native
       tags:
         # full tag
@@ -140,7 +140,7 @@ images:
         BASE_TAG: 'rocq_{matrix[base]}'
         ROCQ_VERSION: '{matrix[rocq][//-/+]}'
         VCS_REF: 'V{matrix[rocq][//-/+]}'
-        ROCQ_EXTRA_OPAM: 'rocq-native coq-bignums'
+        ROCQ_EXTRA_OPAM: 'rocq-native rocq-bignums'
         # +- rocq-native
       tags:
         # full tag
@@ -194,8 +194,8 @@ images:
   #       # TODO: Replace when the rc is tagged
   #       VCS_REF: '{defaults[commit][0:7]}'
   #       # VCS_REF: 'V{matrix[coq][//-/+]}'
-  #       COQ_EXTRA_OPAM: 'coq-bignums'
-  #       # +- coq-native
+  #       COQ_EXTRA_OPAM: 'rocq-bignums'
+  #       # +- rocq-native
   #       # TODO: Replace when the rc is tagged
   #       COQ_INSTALL_SERAPI: 'false'
   #       # COQ_INSTALL_SERAPI: 'true'
@@ -231,8 +231,8 @@ images:
   #       # TODO: Replace when the rc is tagged
   #       VCS_REF: '{defaults[commit][0:7]}'
   #       # VCS_REF: 'V{matrix[coq][//-/+]}'
-  #       COQ_EXTRA_OPAM: 'coq-native coq-bignums'
-  #       # +- coq-native
+  #       COQ_EXTRA_OPAM: 'rocq-native rocq-bignums'
+  #       # +- rocq-native
   #       # TODO: Replace when the rc is tagged
   #       COQ_INSTALL_SERAPI: 'false'
   #       # COQ_INSTALL_SERAPI: 'true'

--- a/rocq/beta/Dockerfile
+++ b/rocq/beta/Dockerfile
@@ -1,7 +1,7 @@
 ARG BASE_TAG="latest"
 FROM rocq/base:${BASE_TAG}
 
-ARG ROCQ_EXTRA_OPAM="coq-bignums"
+ARG ROCQ_EXTRA_OPAM="rocq-bignums"
 ENV ROCQ_EXTRA_OPAM="${ROCQ_EXTRA_OPAM}"
 
 ARG ROCQ_VERSION="dev"

--- a/rocq/dev/Dockerfile
+++ b/rocq/dev/Dockerfile
@@ -1,7 +1,7 @@
 ARG BASE_TAG="latest"
 FROM rocq/base:${BASE_TAG}
 
-ARG ROCQ_EXTRA_OPAM="coq-bignums"
+ARG ROCQ_EXTRA_OPAM="rocq-bignums"
 ENV ROCQ_EXTRA_OPAM="${ROCQ_EXTRA_OPAM}"
 
 ARG ROCQ_VERSION="dev"


### PR DESCRIPTION
Follows-up: https://github.com/coq-community/docker-coq/pull/75

Cc @proux01 @mattam82 @ppedrot FYI:

this is the 8th, last step in the release of the Docker image `rocq/rocq-prover:9.0` (rc1)

You'll be able to announce the image as soon as the CI/CD pipeline triggered by the merge succeeds.
